### PR TITLE
Kill a warning

### DIFF
--- a/magneto/magneto.c
+++ b/magneto/magneto.c
@@ -54,7 +54,7 @@ int main()
   FILE *fp;
 
  printf("\r\nMagneto 1.2\r\n.csv input file name? ");
- scanf("%s",&filename);
+ scanf("%s",filename);
 
  fp = fopen(filename, "r");
  if (fp == NULL) {printf("file not found"); return 0;}


### PR DESCRIPTION
I got this warning:

```
% make magneto
cc     magneto.c   -o magneto
magneto.c:58:13: warning: format specifies type 'char *' but the argument has type 'char (*)[64]' [-Wformat]
 scanf("%s",&filename);
        ~~  ^~~~~~~~~
1 warning generated.
```

Since filename is already a char * buffer, it doesn't need to be a reference to a specific array type.

I also needed to change `#include <malloc.h>` to `#include <stdlib.h>` to compile on my Mac.